### PR TITLE
fix(select.ts): fix empty class values & ':' blocking query

### DIFF
--- a/src/ext/content/select.ts
+++ b/src/ext/content/select.ts
@@ -38,10 +38,14 @@ function init() {
             }
 
             if (el.className) {
-              el.className.split(' ').forEach((str) => {
-                data.content.push({ type: 'class', value: str, key: key, active: true });
-                key++;
-              });
+              el.className
+                .split(' ')
+                .filter((str) => str.trim() !== '')
+                .map((str) => (str.includes(':') ? str.replaceAll(':', '\\:') : str))
+                .forEach((str) => {
+                  data.content.push({ type: 'class', value: str, key: key, active: true });
+                  key++;
+                });
             }
             return data;
           }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
Empty class values are no longer carried into state. ':' within class names are now escaped with
'\\' before sent to state.